### PR TITLE
Add support for dataset-ids to napari-copick plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,34 @@ You can install `napari-copick` via [pip]:
 
     pip install napari-copick
 
-
-
-To install latest development version :
+To install latest development version:
 
     pip install git+https://github.com/kephale/napari-copick.git
 
+## Usage
+
+### Using a copick config file
+
+```bash
+python -m napari_copick.widget --config_path path/to/copick_config.json
+```
+
+### Using dataset IDs from CZ cryoET Data Portal
+
+```bash
+python -m napari_copick.widget --dataset_ids 10440 10441 --overlay_root /path/to/overlay_root
+```
+
+You can specify multiple dataset IDs separated by spaces.
+
+### GUI Usage
+
+The plugin provides an intuitive interface with two loading options:
+
+1. **Load Config File**: Opens a file dialog to select a copick configuration JSON file
+2. **Load from Dataset IDs**: Opens a dialog to enter CZ cryoET Data Portal dataset IDs and overlay root path
+
+After loading, you'll see a hierarchical tree of the project structure that you can navigate to access tomograms, segmentations, and picks.
 
 ## Contributing
 


### PR DESCRIPTION
## Description

This PR adds support for loading projects directly from CZ cryoET Data Portal dataset IDs in the napari-copick plugin, similar to the functionality already implemented in the copick-server repository.

### Key Changes

- Added ability to initialize CopickPlugin with dataset_ids and overlay_root parameters
- Created a DatasetIdDialog for GUI-based input of dataset IDs and overlay root path
- Updated the UI with separate buttons for loading config files vs dataset IDs
- Added CLI arguments to support dataset_ids and overlay_root parameters
- Updated README with documentation on the new functionality

### Usage Examples

#### Command Line

```bash
# Using a config file (existing functionality)
python -m napari_copick.widget --config_path path/to/copick_config.json

# Using dataset IDs (new functionality)
python -m napari_copick.widget --dataset_ids 10440 10441 --overlay_root /path/to/overlay_root
```

#### GUI

The plugin now provides two loading options in the UI:
1. "Load Config File" - Opens a file dialog to select a JSON config file
2. "Load from Dataset IDs" - Opens a dialog to enter dataset IDs and overlay root path

This enhancement makes napari-copick more consistent with the copick-server module and provides users with additional flexibility when working with CZ cryoET Data Portal datasets.

## Testing

Tested with sample dataset IDs to confirm proper loading and functionality of the napari-copick widget.