### PR TITLE
Replace napari-ome-zarr with direct multiscale zarr handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ The plugin provides an intuitive interface with two loading options:
 
 After loading, you'll see a hierarchical tree of the project structure that you can navigate to access tomograms, segmentations, and picks.
 
+### Tomogram Handling
+
+napari-copick now handles multiscale zarr arrays directly:
+
+- Automatically detects and loads all available resolution levels
+- Creates a proper multiscale image stack using napari's native multiscale API
+- Uses dask for efficient lazy loading of large tomogram data
+- Applies appropriate scaling factors based on the voxel size metadata
+
+This direct zarr handling provides better performance and more flexibility compared to relying on external plugins.
+
 ## Contributing
 
 Contributions are very welcome. Tests can be run with [tox], please ensure


### PR DESCRIPTION
## Description

This PR replaces the use of the napari-ome-zarr plugin with direct handling of multiscale zarr arrays using napari's native multiscale API.

### Changes

- Modified the `load_tomogram` method to directly access and load all available resolution levels from zarr files
- Implemented proper multiscale image loading with dask.array for efficient lazy loading of large tomogram data
- Applied appropriate scaling factors based on voxel size metadata
- Added comprehensive docstring explaining the approach
- Updated README with information about the new tomogram handling capabilities

### Benefits

1. **Native Integration**: Uses napari's built-in multiscale API for better integration and performance
2. **Reduced Dependencies**: Removes dependency on the napari-ome-zarr plugin
3. **Better Control**: Provides more direct control over how data is loaded and displayed
4. **Efficient Loading**: Utilizes dask for lazy loading to handle large datasets more efficiently

### Testing Notes

Tested with various multiscale zarr tomograms to ensure proper loading and display of all resolution levels.

## Related Issues

This addresses the need for direct handling of multiscale zarr arrays without relying on external plugins.